### PR TITLE
Add quotes to install_github call

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Currently the package is only available on github and installable with `devtools
 
 ```r
 library(devtools)
-install_github(ropensci/prism)
+install_github("ropensci/prism")
 library(prism)
 ```
 


### PR DESCRIPTION
install_github doesn't work for me without quotes around `ropensci/prism`. R 3.2.1, Ubuntu 15.04.

This adds double quotes following the example at:
https://github.com/hadley/devtools
